### PR TITLE
Add topic to consumed messages

### DIFF
--- a/src/client.jl
+++ b/src/client.jl
@@ -103,7 +103,8 @@ end
 Base.convert(::Type{String}, data::Vector{UInt8}) = String(data)
 
 function Message{K,P}(c_msg::CKafkaMessage) where {K,P}
-    topic = KafkaTopic(Dict(), "<unkown>", c_msg.rkt)
+    topic_name = kafka_topic_name(c_msg.rkt)
+    topic = KafkaTopic(Dict(), topic_name, c_msg.rkt)
     if c_msg.err == 0
         key = _frombytestream(K, unsafe_load_array(c_msg.key, c_msg.key_len))
         payload = _frombytestream(P, unsafe_load_array(c_msg.payload, c_msg.len))

--- a/src/wrapper.jl
+++ b/src/wrapper.jl
@@ -128,7 +128,7 @@ const RD_KAFKA_MSG_F_PARTITION = Cint(8)
 
 function produce(rkt::Ptr{Cvoid}, partition::Integer,
     key::Vector{UInt8}, payload::Vector{UInt8})
-    produce(rkt, partition, key, payload, [])
+    produce(rkt, partition, key, payload, Vector{Cint}())
 end
 
 

--- a/src/wrapper.jl
+++ b/src/wrapper.jl
@@ -245,6 +245,13 @@ function kafka_assign(rk::Ptr{Cvoid}, rkparlist::Ptr{CKafkaTopicPartitionList})
     end
 end
 
+function kafka_topic_name(rkt::Ptr{Cvoid})
+    str_ptr = ccall((:rd_kafka_topic_name, librdkafka), Cstring,
+        (Ptr{Cvoid},),
+        rkt
+    )
+    unsafe_string(str_ptr)
+end
 
 struct CKafkaMessage
     err::Cint

--- a/test/test_consumer.jl
+++ b/test/test_consumer.jl
@@ -1,11 +1,17 @@
 
 @testset "smoke test" begin
-    c = KafkaConsumer("localhost:9092", "my-consumer-group")
-    parlist = [("quickstart-events", 0)]
+    topic = "quickstart-events"
+    c = KafkaConsumer("localhost:9092", "my-consumer-group", Dict("auto.offset.reset" => "earliest"))
+    parlist = [(topic, 0)]
     subscribe(c, parlist)
     timeout_ms = 1000
+    msg = nothing
     for i=1:3
-        msg = poll(String, String, c, timeout_ms)
+        while msg === nothing || msg.payload === nothing
+            msg = poll(String, String, c, timeout_ms)
+        end
         @show(msg)
+        @test msg.topic.topic == topic
+        msg = nothing
     end
 end


### PR DESCRIPTION
* Add the message topic name to the `KafkaTopic` when constructing a `Message` 
* Add some tests to exercise this functionality
* Fix a `produce()` bug that was found during testing

Let me know if you would like me to extract the drive-by bugfix to a separate PR, it isn't really part of this change but it was small enough that I thought it worth keeping in.